### PR TITLE
Feature/falsy client methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ function Shelf (appName, options) {
     return Schema(options)
   }
   return {
-    extend
+    extend,
+    client: storage
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -9,13 +9,15 @@ function Shelf (appName, options) {
 
   let storage = Storage(options)
 
-  function extend (options) {
-    options = options || {}
+  function extend (extendOptions) {
     options.prefix = appName
     options.storage = storage
 
-    options.props = options.props || options.properties
-    options.keys = options.keys || options.key
+    extendOptions = extendOptions || {}
+    options.name = extendOptions.name
+    options.props = extendOptions.props || extendOptions.properties
+    options.keys = extendOptions.keys || extendOptions.key
+    options.methods = extendOptions.methods
 
     if (!options.prefix || typeof options.prefix !== 'string') {
       throw new Error('You need to define a valid prefix for the app')

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const Schema = require('./lib/schema')
 const Storage = require('./lib/storage')
+const Joi = require('joi')
 
 function Shelf (appName, options) {
   options = options || {}
@@ -30,6 +31,13 @@ function Shelf (appName, options) {
     }
     if (!options.keys || options.keys.length <= 0) {
       throw new Error('Model ' + options.name + ': must have at least one key defined')
+    }
+    if (options.methods) {
+      let methodsSchema = Joi.object().pattern(/.*/, Joi.func()).required()
+      let err = Joi.validate(options.methods, methodsSchema)
+      if (err && err.error) {
+        throw new Error('Model ' + options.name + ' has invalid methods: ' + err.error.details[0].message)
+      }
     }
 
     options.keys.forEach((key) => {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -8,6 +8,7 @@ function Schema (options) {
   let prefix = options.prefix
   let name = options.name
   let keys = options.keys
+  let methods = options.methods
 
   let key = util.keyFn(prefix, name, keys)
 
@@ -23,22 +24,31 @@ function Schema (options) {
         }
       })
 
-      let stringModel = JSON.stringify(model)
       model.save = function (cb) {
         let myKey = key(this)
+        let stringModel = JSON.stringify(model)
         storage.set(myKey, stringModel, cb)
       }
 
       // TTL in seconds
       model.saveWithTTL = function (ttl, cb) {
         let myKey = key(this)
+        let stringModel = JSON.stringify(model)
         storage.setex(myKey, ttl, stringModel, cb)
       }
 
       model.del = function (cb) {
-        var myKey = key(this)
+        let myKey = key(this)
         storage.del(myKey, cb)
       }
+
+      if (methods) {
+        let methodsNames = Object.keys(methods)
+        methodsNames.forEach((methodName) => {
+          model[methodName] = methods[methodName]
+        })
+      }
+
       return model
     })
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,7 +23,7 @@ function Util () {
 
       let finalKey = prefix + ':' + name + ':'
       keys.forEach((key) => {
-        if (obj[key]) {
+        if (obj[key] !== null && obj[key] !== undefined) {
           finalKey += obj[key] + ':'
         } else {
           throw new Error('Missing the key ' + key + ' from the keys object')

--- a/test/index.js
+++ b/test/index.js
@@ -145,13 +145,54 @@ lab.experiment('Shelf Init', () => {
     done()
   })
 
+  lab.test('Invalid methods - string', (done) => {
+    let shelfInstance = Shelf('Test', {
+      host: '127.0.0.1',
+      port: 6379
+    })
+
+    Code.expect(
+      () => shelfInstance.extend({
+        name: '123',
+        props: Joi.object().keys({prop1: Joi.string()}),
+        keys: ['prop1'],
+        methods: 'invalid'
+      })
+    ).to.throw(Error, 'Model 123 has invalid methods: \"value\" must be an object')
+
+    done()
+  })
+
+  lab.test('Invalid methods - not functions', (done) => {
+    let shelfInstance = Shelf('Test', {
+      host: '127.0.0.1',
+      port: 6379
+    })
+
+    Code.expect(
+      () => shelfInstance.extend({
+        name: '123',
+        props: Joi.object().keys({prop1: Joi.string()}),
+        keys: ['prop1'],
+        methods: {
+          hi: 1234
+        }
+      })
+    ).to.throw(Error, 'Model 123 has invalid methods: \"hi\" must be a Function')
+
+    done()
+  })
+
   lab.test('OK', (done) => {
     let shelfInstance = Shelf('Test')
 
     shelfInstance.extend({
       name: '123',
       props: Joi.object().keys({prop1: Joi.string()}),
-      keys: ['prop1']
+      keys: ['prop1'],
+      methods: {
+        hi: function () {}
+      }
     })
     done()
   })


### PR DESCRIPTION
Fix - falsy values validation on keys: now accepts 0 has a key
Fix - schema options mutation: was a bug
Fix - Model parsing for saving on redis was being done on the wrong place

Feature - allows defining methods for model instances on a "methods" prop
Feature - exposed client on Shelf through Shelf.client
