### PR TITLE
fix schema properties being bounded only to the last registered schema

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -9,11 +9,12 @@ function Schema (options) {
   let name = options.name
   let keys = options.keys
   let methods = options.methods
+  let props = options.props
 
   let key = util.keyFn(prefix, name, keys)
 
   let Model = function (properties) {
-    return Joi.validate(properties, options.props, (err, model) => {
+    return Joi.validate(properties, props, (err, model) => {
       if (err) {
         throw err
       }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -4,12 +4,14 @@ const Joi = require('joi')
 const util = require('./util')
 
 function Schema (options) {
-  let storage = options.storage
-  let prefix = options.prefix
-  let name = options.name
-  let keys = options.keys
-  let methods = options.methods
-  let props = options.props
+  let optionsClone = Object.assign({}, options)
+
+  let storage = optionsClone.storage
+  let prefix = optionsClone.prefix
+  let name = optionsClone.name
+  let keys = optionsClone.keys
+  let methods = optionsClone.methods
+  let props = optionsClone.props
 
   let key = util.keyFn(prefix, name, keys)
 


### PR DESCRIPTION
Schema has not storing the props locally, so they were changing to the last saved one.

This caused not being able to save new models as they marked as invalid..
