### PR TITLE
fix model to this that caused bugs when object was created from Object.assign

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -29,14 +29,14 @@ function Schema (options) {
 
       model.save = function (cb) {
         let myKey = key(this)
-        let stringModel = JSON.stringify(model)
+        let stringModel = JSON.stringify(this)
         storage.set(myKey, stringModel, cb)
       }
 
       // TTL in seconds
       model.saveWithTTL = function (ttl, cb) {
         let myKey = key(this)
-        let stringModel = JSON.stringify(model)
+        let stringModel = JSON.stringify(this)
         storage.setex(myKey, ttl, stringModel, cb)
       }
 

--- a/test/lib/schema.js
+++ b/test/lib/schema.js
@@ -203,4 +203,40 @@ lab.experiment('Model', () => {
       }
     }
   })
+
+  lab.test('Create model from assign', (done) => {
+    let MyModel = Storage.extend({
+      name: 'myModel',
+      props: Joi.object().keys({
+        prop1: Joi.string(),
+        prop2: Joi.string()
+      }),
+      keys: ['prop1']
+    })
+
+    let model = MyModel({prop1: 'value', prop2: 'value2'})
+
+    let modelB = {prop2: 'value3'}
+
+    model = Object.assign({}, model, modelB)
+
+    model.save((err, message) => {
+      Code.expect(err).to.be.null()
+      Code.expect(message).to.equal('OK')
+      MyModel.get({prop1: 'value'}, (err, model) => {
+        Code.expect(err).to.be.null()
+        Code.expect(model.prop1).to.equal('value')
+        Code.expect(model.prop2).to.equal('value3')
+        model.del((err, nDeleted) => {
+          Code.expect(err).to.be.null()
+          Code.expect(nDeleted).to.equal(1)
+          MyModel.get({prop1: 'value'}, (err, model) => {
+            Code.expect(err).to.be.null()
+            Code.expect(model).to.be.null()
+            done()
+          })
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
let a = Cat({name: 'sissi', race: 'cat'})

let b = {race: 'cute cat'}

let c = Object.assign({}, a, b);

c.save();

we would expect to be stored the {sissi, cute cat} but because the reference to the model was create only  at the first line, and wasn't changed on the object.assign we lost this reference and further updates...

What do you think of this?
